### PR TITLE
feat: Complete NAPICreateRuntime and NAPIFreeRuntime.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ JavaScript 值，概念和操作通常映射到 ECMA-262 语言规范，API 具�
 1. 建议使用 BUILDCONFIG.gn 中定义的 LTS NDK 版本
 2. Hermes 引擎需要先 `cd third_party/hermes && git apply ../hermes_patch.diff`
 3. Android 版本 libhermes.so 包括 fbjni 库，内含 OnLoad.cpp，需要使用 System.load("hermes") 显式加载，不能依赖 Linux 内核的动态库隐式加载
-4. Hermes 引擎 0.8.1 版本内置字节码，需要先编译主机 hermesc，后输入如下命令
+4. Hermes 引擎 0.8.1 版本内置字节码，需要先编译主机 hermesc，指令 `./utils/build/configure.py`，后输入如下命令
 ```
-> cd third_party/hermes/lib/InternalBytecode
+> cd lib/InternalBytecode
 > cat 00-header.js 01-Promise.js 02-AsyncFn.js 99-footer.js > InternalBytecode.js
-> hermesc -O -Wno-undefined-variable -fno-enable-tdz -emit-binary -out=./InternalBytecode.hbc ./InternalBytecode.js
+> ../../build/bin/hermesc -O -Wno-undefined-variable -fno-enable-tdz -emit-binary -out=./InternalBytecode.hbc ./InternalBytecode.js
 > ./xxd.py ./InternalBytecode.hbc > ./InternalBytecode.inc
 ```
 

--- a/include/napi/js_native_api.h
+++ b/include/napi/js_native_api.h
@@ -3,8 +3,6 @@
 
 #include <napi/js_native_api_types.h>
 
-#define NAPI_EXPORT __attribute__((visibility("default")))
-
 EXTERN_C_START
 
 #include <stdbool.h> // NOLINT(modernize-deprecated-headers)
@@ -119,20 +117,25 @@ NAPI_EXPORT NAPIExceptionStatus NAPIRunScript(NAPIEnv env, const char *script, c
 NAPI_EXPORT NAPIExceptionStatus NAPIDefineClass(NAPIEnv env, const char *utf8name, NAPICallback constructor, void *data,
                                                 NAPIValue *result);
 
-NAPI_EXPORT NAPIErrorStatus NAPICreateEnv(NAPIEnv *env);
+NAPI_EXPORT NAPIErrorStatus NAPICreateRuntime(NAPIRuntime *runtime);
 
+NAPI_EXPORT NAPIErrorStatus NAPICreateEnv(NAPIEnv *env, NAPIRuntime runtime);
 
 NAPI_EXPORT NAPICommonStatus NAPIFreeEnv(NAPIEnv env);
+
+NAPI_EXPORT NAPICommonStatus NAPIFreeRuntime(NAPIRuntime runtime);
 
 NAPI_EXPORT NAPIErrorStatus NAPIGetValueStringUTF8(NAPIEnv env, NAPIValue value, const char **result);
 
 NAPI_EXPORT NAPICommonStatus NAPIFreeUTF8String(NAPIEnv env, const char *cString);
 
-NAPI_EXPORT NAPIExceptionStatus NAPICompileToByteBuffer(NAPIEnv env, const char *script, const char *sourceUrl, const uint8_t **byteBuffer, size_t *bufferSize);
+NAPI_EXPORT NAPIExceptionStatus NAPICompileToByteBuffer(NAPIEnv env, const char *script, const char *sourceUrl,
+                                                        const uint8_t **byteBuffer, size_t *bufferSize);
 
 NAPI_EXPORT NAPICommonStatus NAPIFreeByteBuffer(NAPIEnv env, const uint8_t *byteBuffer);
 
-NAPI_EXPORT NAPIExceptionStatus NAPIRunByteBuffer(NAPIEnv env, const uint8_t *byteBuffer, size_t bufferSize, NAPIValue *result);
+NAPI_EXPORT NAPIExceptionStatus NAPIRunByteBuffer(NAPIEnv env, const uint8_t *byteBuffer, size_t bufferSize,
+                                                  NAPIValue *result);
 
 #pragma mark - 间接函数
 

--- a/include/napi/js_native_api_types.h
+++ b/include/napi/js_native_api_types.h
@@ -11,8 +11,11 @@
 #define EXTERN_C_END
 #endif
 
+#define NAPI_EXPORT __attribute__((visibility("default")))
+
 EXTERN_C_START
 
+typedef struct OpaqueNAPIRuntime *NAPIRuntime;
 typedef struct OpaqueNAPIEnv *NAPIEnv;
 typedef struct OpaqueNAPIValue *NAPIValue;
 typedef struct OpaqueNAPIRef *NAPIRef;

--- a/src/js_native_api_hermes.cpp
+++ b/src/js_native_api_hermes.cpp
@@ -14,7 +14,6 @@
 #include <napi/js_native_api.h>
 #include <napi/js_native_api_debugger.h>
 #include <napi/js_native_api_debugger_hermes_types.h>
-#include <string>
 #include <sys/queue.h>
 #include <unordered_set>
 
@@ -24,7 +23,6 @@
 #ifdef HERMES_ENABLE_DEBUGGER
 #include <cxxreact/MessageQueueThread.h>
 #include <hermes/inspector/RuntimeAdapter.h>
-#include <hermes/inspector/chrome/Registration.h>
 #endif
 
 #ifndef LIST_FOREACH_SAFE
@@ -1430,7 +1428,17 @@ NAPIExceptionStatus NAPIDefineClass(NAPIEnv env, const char *utf8name, NAPICallb
     return NAPIExceptionOK;
 }
 
-NAPIErrorStatus NAPICreateEnv(NAPIEnv *env)
+NAPIErrorStatus NAPICreateRuntime(NAPIRuntime *runtime)
+{
+    return NAPIErrorOK;
+}
+
+NAPICommonStatus NAPIFreeRuntime(NAPIRuntime runtime)
+{
+    return NAPICommonOK;
+}
+
+NAPIErrorStatus NAPICreateEnv(NAPIEnv *env, NAPIRuntime runtime)
 {
     CHECK_ARG(env, Error)
 

--- a/src/js_native_api_qjs.c
+++ b/src/js_native_api_qjs.c
@@ -1982,7 +1982,6 @@ NAPI_EXPORT NAPIExceptionStatus NAPIRunByteBuffer(NAPIEnv env, const uint8_t *by
     {
         goto exceptionHandlerWithProcess;
     }
-    JS_FreeValue(env->context, functionValue);
     processPendingTask(env);
     if (result)
     {

--- a/src/js_native_api_qjs.c
+++ b/src/js_native_api_qjs.c
@@ -99,12 +99,21 @@ struct WeakReference
 struct OpaqueNAPIEnv
 {
     JSValue referenceSymbolValue;                       // size_t * 2
+    NAPIRuntime runtime;                                // size_t
     JSContext *context;                                 // size_t
     LIST_HEAD(, OpaqueNAPIHandleScope) handleScopeList; // size_t
     LIST_HEAD(, WeakReference) weakReferenceList;       // size_t
     LIST_HEAD(, OpaqueNAPIRef) strongRefList;           // size_t
     LIST_HEAD(, OpaqueNAPIRef) valueList;               // size_t
     bool isThrowNull;
+};
+
+struct OpaqueNAPIRuntime
+{
+    JSRuntime *runtime;           // size_t
+    JSClassID constructorClassId; // uint32_t
+    JSClassID functionClassId;    // uint32_t
+    JSClassID externalClassId;    // uint32_t
 };
 
 // 这个函数不会修改引用计数和所有权
@@ -264,8 +273,7 @@ typedef struct
 } FunctionInfo;
 
 // classId 必须为 0 才会被分配
-// TODO(ChasonTang): Place into NAPIEnv
-static JSClassID functionClassId = 0;
+// static JSClassID functionClassId = 0;
 
 struct OpaqueNAPICallbackInfo
 {
@@ -279,7 +287,9 @@ struct OpaqueNAPICallbackInfo
 static JSValue callAsFunction(JSContext *ctx, JSValueConst thisVal, int argc, JSValueConst *argv, int magic,
                               JSValue *funcData)
 {
-    if (__builtin_expect(!functionClassId, false))
+    JSRuntime *rt = JS_GetRuntime(ctx);
+    NAPIRuntime runtime = JS_GetRuntimeOpaque(rt);
+    if (__builtin_expect(!runtime->functionClassId, false))
     {
         assert(false && FUNCTION_CLASS_ID_ZERO);
 
@@ -287,7 +297,7 @@ static JSValue callAsFunction(JSContext *ctx, JSValueConst thisVal, int argc, JS
     }
     // 固定 1 参数
     // JS_GetOpaque 不会抛出异常
-    FunctionInfo *functionInfo = JS_GetOpaque(funcData[0], functionClassId);
+    FunctionInfo *functionInfo = JS_GetOpaque(funcData[0], runtime->functionClassId);
     if (__builtin_expect(!functionInfo || !functionInfo->callback || !functionInfo->baseInfo.env, false))
     {
         assert(false && "callAsFunction() body use JS_GetOpaque() return error.");
@@ -370,7 +380,6 @@ static JSValue callAsFunction(JSContext *ctx, JSValueConst thisVal, int argc, JS
 NAPIExceptionStatus napi_create_function(NAPIEnv env, const char *utf8name, NAPICallback cb, void *data,
                                          NAPIValue *result)
 {
-
     NAPI_PREAMBLE(env)
     CHECK_ARG(cb, Exception)
     CHECK_ARG(result, Exception)
@@ -387,7 +396,7 @@ NAPIExceptionStatus napi_create_function(NAPIEnv env, const char *utf8name, NAPI
     functionInfo->baseInfo.data = data;
     functionInfo->callback = cb;
 
-    if (__builtin_expect(!functionClassId, false))
+    if (__builtin_expect(!env->runtime->functionClassId, false))
     {
         assert(false && FUNCTION_CLASS_ID_ZERO);
         free(functionInfo);
@@ -395,7 +404,7 @@ NAPIExceptionStatus napi_create_function(NAPIEnv env, const char *utf8name, NAPI
         return NAPIExceptionGenericFailure;
     }
     // rc: 1
-    JSValue dataValue = JS_NewObjectClass(env->context, (int)functionClassId);
+    JSValue dataValue = JS_NewObjectClass(env->context, (int)env->runtime->functionClassId);
     if (__builtin_expect(JS_IsException(dataValue), false))
     {
         free(functionInfo);
@@ -440,7 +449,7 @@ NAPIExceptionStatus napi_create_function(NAPIEnv env, const char *utf8name, NAPI
     return NAPIExceptionOK;
 }
 
-static JSClassID externalClassId = 0;
+// static JSClassID externalClassId = 0;
 
 NAPICommonStatus napi_typeof(NAPIEnv env, NAPIValue value, NAPIValueType *result)
 {
@@ -474,7 +483,7 @@ NAPICommonStatus napi_typeof(NAPIEnv env, NAPIValue value, NAPIValueType *result
     {
         *result = NAPIFunction;
     }
-    else if (JS_GetOpaque(jsValue, externalClassId))
+    else if (JS_GetOpaque(jsValue, env->runtime->externalClassId))
     {
         // JS_GetOpaque 会检查 classId
         *result = NAPIExternal;
@@ -940,14 +949,14 @@ NAPIExceptionStatus napi_create_external(NAPIEnv env, void *data, NAPIFinalize f
     externalInfo->data = data;
     externalInfo->finalizeHint = finalizeHint;
     externalInfo->finalizeCallback = NULL;
-    if (__builtin_expect(!externalClassId, false))
+    if (__builtin_expect(!env->runtime->externalClassId, false))
     {
         assert(false && "externalClassId must not be 0.");
         free(externalInfo);
 
         return NAPIExceptionGenericFailure;
     }
-    JSValue object = JS_NewObjectClass(env->context, (int)externalClassId);
+    JSValue object = JS_NewObjectClass(env->context, (int)env->runtime->externalClassId);
     if (__builtin_expect(JS_IsException(object), false))
     {
         free(externalInfo);
@@ -977,19 +986,19 @@ NAPIErrorStatus napi_get_value_external(NAPIEnv env, NAPIValue value, void **res
     CHECK_ARG(value, Error)
     CHECK_ARG(result, Error)
 
-    if (__builtin_expect(!externalClassId, false))
+    if (__builtin_expect(!env->runtime->externalClassId, false))
     {
         assert(false && "externalClassId must not be 0.");
 
         return NAPIErrorGenericFailure;
     }
-    ExternalInfo *externalInfo = JS_GetOpaque(*((JSValue *)value), externalClassId);
+    ExternalInfo *externalInfo = JS_GetOpaque(*((JSValue *)value), env->runtime->externalClassId);
     *result = externalInfo ? externalInfo->data : NULL;
 
     return NAPIErrorOK;
 }
 
-static uint8_t contextCount = 0;
+// static uint8_t contextCount = 0;
 
 static void referenceFinalize(void *finalizeData, void *finalizeHint)
 {
@@ -1496,25 +1505,27 @@ NAPIExceptionStatus NAPIRunScript(NAPIEnv env, const char *script, const char *s
 
 static void functionFinalizer(JSRuntime *rt, JSValue val)
 {
-    if (__builtin_expect(!functionClassId, false))
+    NAPIRuntime runtime = JS_GetRuntimeOpaque(rt);
+    if (__builtin_expect(!runtime->functionClassId, false))
     {
         assert(false && FUNCTION_CLASS_ID_ZERO);
 
         return;
     }
-    FunctionInfo *functionInfo = JS_GetOpaque(val, functionClassId);
+    FunctionInfo *functionInfo = JS_GetOpaque(val, runtime->functionClassId);
     free(functionInfo);
 }
 
 static void externalFinalizer(JSRuntime *rt, JSValue val)
 {
-    if (__builtin_expect(!externalClassId, false))
+    NAPIRuntime runtime = JS_GetRuntimeOpaque(rt);
+    if (__builtin_expect(!runtime->externalClassId, false))
     {
         assert(false && FUNCTION_CLASS_ID_ZERO);
 
         return;
     }
-    ExternalInfo *externalInfo = JS_GetOpaque(val, externalClassId);
+    ExternalInfo *externalInfo = JS_GetOpaque(val, runtime->externalClassId);
     if (externalInfo && externalInfo->finalizeCallback)
     {
         externalInfo->finalizeCallback(externalInfo->data, externalInfo->finalizeHint);
@@ -1522,7 +1533,7 @@ static void externalFinalizer(JSRuntime *rt, JSValue val)
     free(externalInfo);
 }
 
-static JSRuntime *runtime = NULL;
+// static JSRuntime *runtime = NULL;
 
 typedef struct
 {
@@ -1530,22 +1541,25 @@ typedef struct
     JSClassID classId; // uint32_t
 } ConstructorInfo;
 
-static JSClassID constructorClassId = 0;
+// static JSClassID constructorClassId = 0;
 
 static void constructorFinalizer(JSRuntime *rt, JSValue val)
 {
-    if (__builtin_expect(!constructorClassId, false))
+    NAPIRuntime runtime = JS_GetRuntimeOpaque(rt);
+    if (__builtin_expect(!runtime->constructorClassId, false))
     {
         assert(false && CONSTRUCTOR_CLASS_ID_ZERO);
 
         return;
     }
-    ConstructorInfo *constructorInfo = JS_GetOpaque(val, constructorClassId);
+    ConstructorInfo *constructorInfo = JS_GetOpaque(val, runtime->constructorClassId);
     free(constructorInfo);
 }
 
 static JSValue callAsConstructor(JSContext *ctx, JSValueConst newTarget, int argc, JSValueConst *argv)
 {
+    JSRuntime *rt = JS_GetRuntime(ctx);
+    NAPIRuntime runtime = JS_GetRuntimeOpaque(rt);
     JSValue prototypeValue = JS_GetPropertyStr(ctx, newTarget, "prototype");
     if (JS_IsException(prototypeValue))
     {
@@ -1553,13 +1567,13 @@ static JSValue callAsConstructor(JSContext *ctx, JSValueConst newTarget, int arg
 
         return prototypeValue;
     }
-    if (__builtin_expect(!constructorClassId, false))
+    if (__builtin_expect(!runtime->constructorClassId, false))
     {
         assert(false && CONSTRUCTOR_CLASS_ID_ZERO);
 
         return undefinedValue;
     }
-    ConstructorInfo *constructorInfo = JS_GetOpaque(prototypeValue, constructorClassId);
+    ConstructorInfo *constructorInfo = JS_GetOpaque(prototypeValue, runtime->constructorClassId);
     JS_FreeValue(ctx, prototypeValue);
     if (__builtin_expect(!constructorInfo || !constructorInfo->functionInfo.baseInfo.env ||
                              !constructorInfo->functionInfo.callback || !constructorInfo->classId,
@@ -1639,20 +1653,20 @@ NAPIExceptionStatus NAPIDefineClass(NAPIEnv env, const char *utf8name, NAPICallb
     constructorInfo->classId = 0;
     JS_NewClassID(&constructorInfo->classId);
     JSClassDef classDef = {utf8name ?: "", NULL, NULL, NULL, NULL};
-    int status = JS_NewClass(runtime, constructorInfo->classId, &classDef);
+    int status = JS_NewClass(env->runtime->runtime, constructorInfo->classId, &classDef);
     if (__builtin_expect(status == -1, false))
     {
         free(constructorInfo);
 
         return NAPIExceptionPendingException;
     }
-    if (__builtin_expect(!constructorClassId, false))
+    if (__builtin_expect(!env->runtime->constructorClassId, false))
     {
         assert(false && CONSTRUCTOR_CLASS_ID_ZERO);
 
         return NAPIExceptionGenericFailure;
     }
-    JSValue prototype = JS_NewObjectClass(env->context, (int)constructorClassId);
+    JSValue prototype = JS_NewObjectClass(env->context, (int)env->runtime->constructorClassId);
     if (__builtin_expect(JS_IsException(prototype), false))
     {
         free(constructorInfo);
@@ -1689,81 +1703,82 @@ NAPIExceptionStatus NAPIDefineClass(NAPIEnv env, const char *utf8name, NAPICallb
     return NAPIExceptionOK;
 }
 
-// NAPIGenericFailure/NAPIMemoryError
-NAPIErrorStatus NAPICreateEnv(NAPIEnv *env)
+NAPIErrorStatus NAPICreateRuntime(NAPIRuntime *runtime)
 {
-    CHECK_ARG(env, Error)
+    CHECK_ARG(runtime, Error)
 
-    if (__builtin_expect((runtime && !contextCount) || (!runtime && contextCount), false))
+    *runtime = malloc(sizeof(struct OpaqueNAPIRuntime));
+    RETURN_STATUS_IF_FALSE(*runtime, NAPIErrorMemoryError)
+    (*runtime)->runtime = JS_NewRuntime();
+    // JS_NewClassID only accept 0.
+    // So we initialize classId field to 0.
+    (*runtime)->constructorClassId = 0;
+    (*runtime)->functionClassId = 0;
+    (*runtime)->externalClassId = 0;
+    if (!(*runtime)->runtime)
     {
-        assert(false);
+        free(*runtime);
+
+        return NAPIErrorMemoryError;
+    }
+    JS_SetRuntimeOpaque((*runtime)->runtime, *runtime);
+    // 一定成功
+    JS_NewClassID(&(*runtime)->constructorClassId);
+    JS_NewClassID(&(*runtime)->functionClassId);
+    JS_NewClassID(&(*runtime)->externalClassId);
+    JSClassDef classDef = {"External", externalFinalizer, NULL, NULL, NULL};
+    // JS_NewClass -> JS_NewClass1 返回值只有 -1 和 0
+    int status = JS_NewClass((*runtime)->runtime, (*runtime)->externalClassId, &classDef);
+    if (__builtin_expect(status == -1, false))
+    {
+        JS_FreeRuntime((*runtime)->runtime);
+        free(*runtime);
 
         return NAPIErrorGenericFailure;
     }
+
+    classDef.class_name = "FunctionData";
+    classDef.finalizer = functionFinalizer;
+    status = JS_NewClass((*runtime)->runtime, (*runtime)->functionClassId, &classDef);
+    if (__builtin_expect(status == -1, false))
+    {
+        JS_FreeRuntime((*runtime)->runtime);
+        free(*runtime);
+
+        return NAPIErrorGenericFailure;
+    }
+
+    classDef.class_name = "ConstructorPrototype";
+    classDef.finalizer = constructorFinalizer;
+    status = JS_NewClass((*runtime)->runtime, (*runtime)->constructorClassId, &classDef);
+    if (__builtin_expect(status == -1, false))
+    {
+        JS_FreeRuntime((*runtime)->runtime);
+        free(*runtime);
+
+        return NAPIErrorGenericFailure;
+    }
+
+    return NAPIErrorOK;
+}
+
+// NAPIGenericFailure/NAPIMemoryError
+NAPIErrorStatus NAPICreateEnv(NAPIEnv *env, NAPIRuntime runtime)
+{
+    CHECK_ARG(env, Error)
+    CHECK_ARG(runtime, Error)
+
     // Resource - NAPIEnv
     *env = malloc(sizeof(struct OpaqueNAPIEnv));
     RETURN_STATUS_IF_FALSE(*env, NAPIErrorMemoryError)
+    (*env)->runtime = runtime;
 
-    // Resource - JSRuntime + JSClassID
-    JSRuntime *rt = runtime;
-    JSClassID ctorClassId = constructorClassId;
-    JSClassID funcClassId = functionClassId;
-    JSClassID extClassId = externalClassId;
-
-    if (!rt)
-    {
-        rt = JS_NewRuntime();
-        if (__builtin_expect(!rt, false))
-        {
-            free(*env);
-
-            return NAPIErrorMemoryError;
-        }
-        // 一定成功
-        JS_NewClassID(&ctorClassId);
-        JS_NewClassID(&funcClassId);
-        JS_NewClassID(&extClassId);
-
-        JSClassDef classDef = {"External", externalFinalizer, NULL, NULL, NULL};
-        // JS_NewClass -> JS_NewClass1 返回值只有 -1 和 0
-        int status = JS_NewClass(rt, extClassId, &classDef);
-        if (__builtin_expect(status == -1, false))
-        {
-            JS_FreeRuntime(rt);
-            free(*env);
-
-            return NAPIErrorGenericFailure;
-        }
-
-        classDef.class_name = "FunctionData";
-        classDef.finalizer = functionFinalizer;
-        status = JS_NewClass(rt, funcClassId, &classDef);
-        if (__builtin_expect(status == -1, false))
-        {
-            JS_FreeRuntime(rt);
-            free(*env);
-
-            return NAPIErrorGenericFailure;
-        }
-
-        classDef.class_name = "ConstructorPrototype";
-        classDef.finalizer = constructorFinalizer;
-        status = JS_NewClass(rt, ctorClassId, &classDef);
-        if (__builtin_expect(status == -1, false))
-        {
-            JS_FreeRuntime(rt);
-            free(*env);
-
-            return NAPIErrorGenericFailure;
-        }
-    }
     // Resource - JSContext
-    JSContext *context = JS_NewContext(rt);
+    JSContext *context = JS_NewContext(runtime->runtime);
     //    js_std_add_helpers(context, 0, NULL);
     if (__builtin_expect(!context, false))
     {
         free(*env);
-        JS_FreeRuntime(rt);
 
         return NAPIErrorMemoryError;
     }
@@ -1771,45 +1786,36 @@ NAPIErrorStatus NAPICreateEnv(NAPIEnv *env)
     if (__builtin_expect(JS_IsException(prototype), false))
     {
         JS_FreeContext(context);
-        JS_FreeRuntime(rt);
         free(*env);
 
         return NAPIErrorGenericFailure;
     }
-    JS_SetClassProto(context, extClassId, prototype);
+    JS_SetClassProto(context, runtime->externalClassId, prototype);
     prototype = JS_NewObject(context);
     if (__builtin_expect(JS_IsException(prototype), false))
     {
         JS_FreeContext(context);
-        JS_FreeRuntime(rt);
         free(*env);
 
         return NAPIErrorGenericFailure;
     }
-    JS_SetClassProto(context, ctorClassId, prototype);
+    JS_SetClassProto(context, runtime->constructorClassId, prototype);
     const char *string = "(function () { return Symbol(\"reference\") })();";
     (*env)->referenceSymbolValue =
         JS_Eval(context, string, strlen(string), "https://n-api.com/qjs_reference_symbol.js", JS_EVAL_TYPE_GLOBAL);
     if (__builtin_expect(JS_IsException((*env)->referenceSymbolValue), false))
     {
         JS_FreeContext(context);
-        JS_FreeRuntime(rt);
         free(*env);
 
         return NAPIErrorGenericFailure;
     }
-    contextCount += 1;
     (*env)->context = context;
     (*env)->isThrowNull = false;
     LIST_INIT(&(*env)->handleScopeList);
     LIST_INIT(&(*env)->weakReferenceList);
     LIST_INIT(&(*env)->valueList);
     LIST_INIT(&(*env)->strongRefList);
-
-    constructorClassId = ctorClassId;
-    functionClassId = funcClassId;
-    externalClassId = extClassId;
-    runtime = rt;
 
     return NAPIErrorOK;
 }
@@ -1858,16 +1864,16 @@ NAPICommonStatus NAPIFreeEnv(NAPIEnv env)
     }
     JS_FreeValue(env->context, env->referenceSymbolValue);
     JS_FreeContext(env->context);
-    if (--contextCount == 0 && runtime)
-    {
-        // virtualMachine 不能为 NULL
-        JS_FreeRuntime(runtime);
-        runtime = NULL;
-        constructorClassId = 0;
-        functionClassId = 0;
-        externalClassId = 0;
-    }
     free(env);
+
+    return NAPICommonOK;
+}
+
+NAPICommonStatus NAPIFreeRuntime(NAPIRuntime runtime)
+{
+    CHECK_ARG(runtime, Common)
+
+    JS_FreeRuntime(runtime->runtime);
 
     return NAPICommonOK;
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,8 +1,10 @@
 #include <cassert>
-#include <test.h>
 #include <napi/js_native_api_debugger.h>
+#include <test.h>
 
 NAPIEnv globalEnv = nullptr;
+
+NAPIRuntime globalRuntime = nullptr;
 
 bool finalizeIsCalled = false;
 
@@ -33,12 +35,11 @@ class NAPIEnvironment : public ::testing::Environment
     // Override this to define how to set up the environment.
     void SetUp() override
     {
-
-        ASSERT_EQ(NAPICreateEnv(&globalEnv), NAPIErrorOK);
+        ASSERT_EQ(NAPICreateRuntime(&globalRuntime), NAPIErrorOK);
+        ASSERT_EQ(NAPICreateEnv(&globalEnv, globalRuntime), NAPIErrorOK);
         NAPIHandleScope handleScope;
 
         NAPIEnableDebugger(globalEnv, "test", true);
-
 
         ASSERT_EQ(napi_open_handle_scope(globalEnv, &handleScope), NAPIErrorOK);
         NAPIValue assertValue;
@@ -55,6 +56,7 @@ class NAPIEnvironment : public ::testing::Environment
     void TearDown() override
     {
         NAPIFreeEnv(globalEnv);
+        NAPIFreeRuntime(globalRuntime);
         ASSERT_TRUE(finalizeIsCalled);
     }
 };
@@ -64,7 +66,6 @@ int main(int argc, char **argv)
 {
     ::testing::AddGlobalTestEnvironment(new NAPIEnvironment());
     ::testing::InitGoogleTest(&argc, argv);
-
 
     return RUN_ALL_TESTS();
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -39,7 +39,7 @@ class NAPIEnvironment : public ::testing::Environment
         ASSERT_EQ(NAPICreateEnv(&globalEnv, globalRuntime), NAPIErrorOK);
         NAPIHandleScope handleScope;
 
-        NAPIEnableDebugger(globalEnv, "test", true);
+//        NAPIEnableDebugger(globalEnv, "test", true);
 
         ASSERT_EQ(napi_open_handle_scope(globalEnv, &handleScope), NAPIErrorOK);
         NAPIValue assertValue;


### PR DESCRIPTION
1. Fix QuickJS bytecode free twice error.